### PR TITLE
added forget password functionality

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   sessions           Session[]
   messages           Message[]
   verifyCode         String
+  forgotOTP          String?
   verifyCodeExpiry   DateTime
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt

--- a/src/app/(auth)/forgot-password/email/page.tsx
+++ b/src/app/(auth)/forgot-password/email/page.tsx
@@ -1,3 +1,4 @@
+
 /* eslint-disable react-hooks/rules-of-hooks */
 "use client";
 
@@ -18,34 +19,34 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { signInSchema } from "@/schemas/signInSchema";
+import { emailSchema } from "@/schemas/emailSchema";
 
 const Page = () => {
     const router = useRouter();
     const [hidden, setHidden] = useState(true)
 
     //zod implementation
-    const form = useForm<z.infer<typeof signInSchema>>({
-        resolver: zodResolver(signInSchema),
+    const form = useForm<z.infer<typeof emailSchema>>({
+        resolver: zodResolver(emailSchema),
         defaultValues: {
-            identifier: "",
-            password: "",
+            email: ""
         },
     });
 
-    const onSubmit = async (data: z.infer<typeof signInSchema>) => {
-        const result = await signIn('credentials', {
-            redirect:false,
-            identifier: data.identifier,
-            password:data.password
+    const onSubmit = async (data: z.infer<typeof emailSchema>) => {
+      try {
+        const response = await axios.post(`/api/forgot-password/sendotp`, {
+            email: data.email
         })
-
-        if (result?.error) {
-            toast.error("Login Failed", { description: "Incorrect username or password" })
-        }
-
-        if (result?.url) {
-            router.replace("/dashboard")
-        }
+        console.log(response)
+        toast.success('Success', { description: response.data.message })
+        router.replace(`/forgot-password/otp-verify/${response.data.username}`)
+    } catch (error) {
+        console.error("Error in signup of user", error);
+        const axiosError = error as AxiosError<ApiResponse>;
+        let errorMessage = axiosError.response?.data.message;
+        toast.error("Sign-up failed", { description: errorMessage })
+    }
     };
 
     return (
@@ -53,43 +54,26 @@ const Page = () => {
             <div className="w-full max-w-md p-8 space-y-8 rounded-3xl shadow-md border">
                 <div className="text-center">
                     <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl mb-6">
-                        Join <br />Truth-Tunnel
+                        Reset Password
                     </h1>
                     <p className="mb-4">
-                        Sign In to start your anonymous adventure.
+                        Enter your email
                     </p>
                 </div>
 
                 <Form {...form}>
                     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
                         <FormField
-                            name="identifier"
+                            name="email"
                             control={form.control}
                             render={({ field }) => (
                                 <FormItem>
-                                    <FormLabel>Email/Username</FormLabel>
-                                    <FormControl>
-                                        <Input className="rounded-xl" placeholder="Enter Email/Username" {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            name="password"
-                            control={form.control}
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel className="flex justify-between">
-                                        <p>Password</p>
-                                        <Link href="/forgot-password/email">Forgot Password?</Link>
-                                        </FormLabel>
+                                    <FormLabel className="">
+                                        <p>Email</p>
+                                    </FormLabel>
                                     <div className="relative">
-                                        <div className="absolute right-4 top-1/2 -translate-y-1/2 py-2" onClick={()=>setHidden(!hidden)}>
-                                            { hidden ? <EyeOff/> : <Eye /> }
-                                        </div>
                                         <FormControl>
-                                            <Input className="rounded-xl" type={hidden ? "password" : "text"} placeholder="Enter Password" {...field} />
+                                            <Input className="rounded-xl" type="email" placeholder="Enter Email" {...field} />
                                         </FormControl>
                                     </div>
                                     <FormMessage />
@@ -97,14 +81,14 @@ const Page = () => {
                             )}
                         />
                         <Button type="submit" className="rounded-xl">
-                            Sign In
+                            Send OTP
                         </Button>
                     </form>
                 </Form>
                 <div className="text-center mt-4">
                     <p>
-                        Don{"'"}t have an account?{' '}
-                        <Link href="/sign-up" className="text-blue-600 hover:text-blue-800">Sign Up</Link>
+                        Remembered Password?
+                        <Link href="/sign-in" className="text-blue-600 hover:text-blue-800 ml-2">Sign In</Link>
                     </p>
                 </div>
             </div>

--- a/src/app/(auth)/forgot-password/otp-verify/[username]/page.tsx
+++ b/src/app/(auth)/forgot-password/otp-verify/[username]/page.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { Button } from '@/components/ui/button';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp';
+import { toast } from 'sonner';
+import { verifySchema } from '@/schemas/verifySchema';
+import { ApiResponse } from '@/types/ApiResponse';
+import { zodResolver } from '@hookform/resolvers/zod';
+import axios, { AxiosError } from 'axios';
+import { useParams, useRouter } from 'next/navigation';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+const VerifyAccount = () => {
+    const router = useRouter()
+
+    const params = useParams<{ username: string }>()
+
+    const form = useForm<z.infer<typeof verifySchema>>({
+        resolver: zodResolver(verifySchema),
+    });
+
+    const onSubmit = async (data: z.infer<typeof verifySchema>) => {
+        try {
+            const response = await axios.post(`/api/forgot-password/verifyotp`, {
+                username: params.username,
+                otp: data.code
+            })
+            toast.success('Success', { description: response.data.message })
+            router.replace(`/forgot-password/reset-password/${params.username}`)
+        } catch (error) {
+            console.error("Error in signup of user", error);
+            const axiosError = error as AxiosError<ApiResponse>;
+            let errorMessage = axiosError.response?.data.message;
+            toast.error("Sign-up failed", { description: errorMessage })
+        }
+    }
+
+
+    return (
+        <div className="flex justify-center items-center min-h-screen">
+            <div className="w-full max-w-md p-8 space-y-8 rounded-lg shadow-md border">
+                <div className="text-center">
+                    <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl mb-6">
+                        Verify Your Account
+                    </h1>
+                    <p className="mb-4">
+                        Enter the verification code sent to your email
+                    </p>
+                </div>
+                <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="w-2/3 space-y-6">
+                        <FormField
+                            name="code"
+                            control={form.control}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Verification Code</FormLabel>
+                                    <FormControl>
+                                        <InputOTP maxLength={6} {...field}>
+                                            <InputOTPGroup>
+                                                <InputOTPSlot index={0} />
+                                                <InputOTPSlot index={1} />
+                                                <InputOTPSlot index={2} />
+                                                <InputOTPSlot index={3} />
+                                                <InputOTPSlot index={4} />
+                                                <InputOTPSlot index={5} />
+                                            </InputOTPGroup>
+                                        </InputOTP>
+                                    </FormControl>
+                                    <FormDescription>
+                                        Please enter the Verification code sent to your email.
+                                    </FormDescription>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <Button type="submit" className='rounded-2xl'>Submit</Button>
+                    </form>
+                </Form>
+            </div>
+        </div>
+    );
+}
+
+export default VerifyAccount;

--- a/src/app/(auth)/forgot-password/reset-password/[username]/page.tsx
+++ b/src/app/(auth)/forgot-password/reset-password/[username]/page.tsx
@@ -54,10 +54,10 @@ const Page = () => {
             <div className="w-full max-w-md p-8 space-y-8 rounded-3xl shadow-md border">
                 <div className="text-center">
                     <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl mb-6">
-                        Join <br />Truth-Tunnel
+                        Enter <br />New Password
                     </h1>
                     <p className="mb-4">
-                        Sign In to start your anonymous adventure.
+                        change your password.
                     </p>
                 </div>
 

--- a/src/app/(auth)/forgot-password/reset-password/[username]/page.tsx
+++ b/src/app/(auth)/forgot-password/reset-password/[username]/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import {signIn} from "next-auth/react"
 import { useEffect, useState, useCallback } from "react";
 import { useDebounce } from 'use-debounce';
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { signUpSchema } from "@/schemas/signUpSchema";
 import axios, { AxiosError } from "axios";
 import { ApiResponse } from "@/types/ApiResponse";
@@ -17,34 +17,35 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
-import { signInSchema } from "@/schemas/signInSchema";
+import { resetPasswordSchema } from "@/schemas/resetPasswordSchema";
 
 const Page = () => {
     const router = useRouter();
     const [hidden, setHidden] = useState(true)
+    const params = useParams<{ username: string }>()
 
     //zod implementation
-    const form = useForm<z.infer<typeof signInSchema>>({
-        resolver: zodResolver(signInSchema),
+    const form = useForm<z.infer<typeof resetPasswordSchema>>({
+        resolver: zodResolver(resetPasswordSchema),
         defaultValues: {
-            identifier: "",
             password: "",
+            confirmPassword: "",
         },
     });
 
-    const onSubmit = async (data: z.infer<typeof signInSchema>) => {
-        const result = await signIn('credentials', {
-            redirect:false,
-            identifier: data.identifier,
-            password:data.password
-        })
+    const onSubmit = async (data: z.infer<typeof resetPasswordSchema>) => {
+        console.log("hee");
+        
+        try {
+            const response = await axios.post(`/api/forgot-password/newpassword`, {
+                username: params.username,
+                password: data.password
+            })
+              toast.success('Success', { description: response.data.message })
 
-        if (result?.error) {
-            toast.error("Login Failed", { description: "Incorrect username or password" })
-        }
-
-        if (result?.url) {
-            router.replace("/dashboard")
+          router.replace("/sign-in")
+        } catch (error) {
+          toast.error("password reset failed", { description: "error in resetting password" })
         }
     };
 
@@ -62,19 +63,7 @@ const Page = () => {
 
                 <Form {...form}>
                     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                        <FormField
-                            name="identifier"
-                            control={form.control}
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Email/Username</FormLabel>
-                                    <FormControl>
-                                        <Input className="rounded-xl" placeholder="Enter Email/Username" {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
+                        
                         <FormField
                             name="password"
                             control={form.control}
@@ -82,8 +71,27 @@ const Page = () => {
                                 <FormItem>
                                     <FormLabel className="flex justify-between">
                                         <p>Password</p>
-                                        <Link href="/forgot-password/email">Forgot Password?</Link>
-                                        </FormLabel>
+                                    </FormLabel>
+                                    <div className="relative">
+                                        <div className="absolute right-4 top-1/2 -translate-y-1/2 py-2" onClick={()=>setHidden(!hidden)}>
+                                            { hidden ? <EyeOff/> : <Eye /> }
+                                        </div>
+                                        <FormControl>
+                                            <Input className="rounded-xl" type={hidden ? "password" : "text"} placeholder="Enter Password" {...field} />
+                                        </FormControl>
+                                    </div>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            name="confirmPassword"
+                            control={form.control}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel className="flex justify-between">
+                                        <p>Confirm Password</p>
+                                    </FormLabel>
                                     <div className="relative">
                                         <div className="absolute right-4 top-1/2 -translate-y-1/2 py-2" onClick={()=>setHidden(!hidden)}>
                                             { hidden ? <EyeOff/> : <Eye /> }
@@ -97,16 +105,10 @@ const Page = () => {
                             )}
                         />
                         <Button type="submit" className="rounded-xl">
-                            Sign In
+                            Reset Password
                         </Button>
                     </form>
                 </Form>
-                <div className="text-center mt-4">
-                    <p>
-                        Don{"'"}t have an account?{' '}
-                        <Link href="/sign-up" className="text-blue-600 hover:text-blue-800">Sign Up</Link>
-                    </p>
-                </div>
             </div>
         </div>
     );

--- a/src/app/api/forgot-password/newpassword/route.ts
+++ b/src/app/api/forgot-password/newpassword/route.ts
@@ -1,0 +1,49 @@
+
+import db from "@/lib/db";
+import bcrypt from "bcryptjs";
+
+export async function POST(request: Request) {
+
+    try {
+        const { username, password } = await request.json();
+        
+        const existingUser = await db.user.findUnique({
+            where: {
+                username
+            }
+        })
+        if (!existingUser) {
+            return new Response(JSON.stringify({
+                success: false,
+                message: "user not found"
+            }), {
+                status: 400
+            });
+        }
+        
+        const hashPassword = await bcrypt.hash(password, 10);
+
+        await db.user.update({
+            where: {
+                username,
+            },
+            data: {
+                password: hashPassword,
+            }
+        })
+
+        return new Response(JSON.stringify({
+            success: true,
+            message: "password changed successfully."
+        }), { status: 201 });
+
+    } catch (error) {
+        console.error("Error sending mail", error);
+        return new Response(JSON.stringify({
+            success: false,
+            message: "Password updation unsuccessful, try again later"
+        }), {
+            status: 500
+        });
+    }
+}

--- a/src/app/api/forgot-password/sendotp/route.ts
+++ b/src/app/api/forgot-password/sendotp/route.ts
@@ -1,0 +1,61 @@
+import { sendVerificationEmail } from "@/helpers/sendVerificationEmail";
+import db from "@/lib/db";
+
+export async function POST(request: Request) {
+
+
+    try {
+        const { email} = await request.json();
+
+        const existingUser = await db.user.findUnique({
+            where: {
+                email
+            }
+        })
+        if (!existingUser) {
+            return new Response(JSON.stringify({
+                success: false,
+                message: "user not found"
+            }), {
+                status: 400
+            });
+        }
+
+        const verifyCode = Math.floor(100000 + Math.random() * 900000).toString();
+
+        await db.user.update({
+            where: {
+                email,
+            },
+            data: {
+                forgotOTP : verifyCode,
+            }
+        })
+
+        // Send verification email
+        const emailResponse = await sendVerificationEmail(email, existingUser.username, verifyCode, true);
+
+        if (!emailResponse.success) {
+            return new Response(JSON.stringify({
+                success: false,
+                message: emailResponse.message,
+                
+            }), { status: 500 });
+        }
+
+        return new Response(JSON.stringify({
+            success: true,
+            message: "Verification code sent.",
+            username: existingUser.username
+        }), { status: 201 });
+
+    } catch (error) {
+        console.error("Error sending mail", error);
+        return new Response(JSON.stringify({
+            success: false,
+            message: "Error sending mail"
+        }), {
+            status: 500
+        });
+    }
+}

--- a/src/app/api/forgot-password/verifyotp/route.ts
+++ b/src/app/api/forgot-password/verifyotp/route.ts
@@ -1,0 +1,58 @@
+import { sendVerificationEmail } from "@/helpers/sendVerificationEmail";
+import db from "@/lib/db";
+
+export async function POST(request: Request) {
+
+
+    try {
+        const { username, otp } = await request.json();
+        const existingUser = await db.user.findUnique({
+            where: {
+                username
+            }
+        })
+        if (!existingUser) {
+            return new Response(JSON.stringify({
+                success: false,
+                message: "user not found"
+            }), {
+                status: 400
+            });
+        }
+        console.log(existingUser.forgotOTP)
+        console.log(otp);
+        
+
+        if(existingUser.forgotOTP !== otp){
+            return new Response(JSON.stringify({
+                success: false,
+                message: "Invalid OTP"
+            }), {
+                status: 400
+            });
+        }
+
+        await db.user.update({
+            where: {
+                username
+            },
+            data: {
+                forgotOTP : "",
+            }
+        })
+
+        return new Response(JSON.stringify({
+            success: true,
+            message: "Verification successful."
+        }), { status: 201 });
+
+    } catch (error) {
+        console.error("Error sending mail", error);
+        return new Response(JSON.stringify({
+            success: false,
+            message: "verification unsuccessful, try again later"
+        }), {
+            status: 500
+        });
+    }
+}

--- a/src/app/api/sign-up/route.ts
+++ b/src/app/api/sign-up/route.ts
@@ -79,7 +79,6 @@ export async function POST(request: Request) {
                     verifyCodeExpiry: expiryDate,
                     isVerified: false,
                     isAcceptingMessage: true,
-
                 }
             })
         }

--- a/src/helpers/sendVerificationEmail.ts
+++ b/src/helpers/sendVerificationEmail.ts
@@ -32,7 +32,7 @@ export async function sendVerificationEmail(email: string, username: string, ver
                             <h2>Hello ${username},</h2>
                         </div>
                         <div>
-                            <p>${forgot ? "Yout forgot password OTP" : "Thank you for registering. Please use the following verification code to complete your registration."}</p>
+                            <p>${forgot ? "Your forgot password OTP" : "Thank you for registering. Please use the following verification code to complete your registration."}</p>
                         </div>
                         <div>
                             <p><strong>${verifyCode}</strong></p>

--- a/src/helpers/sendVerificationEmail.ts
+++ b/src/helpers/sendVerificationEmail.ts
@@ -19,7 +19,7 @@ transporter.verify().then(() => {
     console.error("Error setting up nodemailer transporter:", error);
 });
 
-export async function sendVerificationEmail(email: string, username: string, verifyCode: string): Promise<{ success: boolean, message?: string }> {
+export async function sendVerificationEmail(email: string, username: string, verifyCode: string, forgot: boolean = false): Promise<{ success: boolean, message?: string }> {
     try {
         const htmlContent = `
             <html lang="en">
@@ -32,7 +32,7 @@ export async function sendVerificationEmail(email: string, username: string, ver
                             <h2>Hello ${username},</h2>
                         </div>
                         <div>
-                            <p>Thank you for registering. Please use the following verification code to complete your registration.</p>
+                            <p>${forgot ? "Yout forgot password OTP" : "Thank you for registering. Please use the following verification code to complete your registration."}</p>
                         </div>
                         <div>
                             <p><strong>${verifyCode}</strong></p>

--- a/src/schemas/emailSchema.ts
+++ b/src/schemas/emailSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const emailSchema = z.object({
+    email: z
+        .string()
+        .email({ message: "Invalid email address" }),
+})

--- a/src/schemas/resetPasswordSchema.ts
+++ b/src/schemas/resetPasswordSchema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const resetPasswordSchema = z.object({
+    password: z.string(),
+    confirmPassword:z.string()
+})


### PR DESCRIPTION
Closes #27 

Implemented forgot password backend and frontend

signin page: 
![Screenshot 2024-10-09 194241](https://github.com/user-attachments/assets/bbd12758-aa6c-4ec4-8a89-834bfddb96db)

email page:
![Screenshot 2024-10-09 194317](https://github.com/user-attachments/assets/a8332aa0-dbd0-489d-b2ad-ffb4f048c99f)

OTP verification:
![Screenshot 2024-10-09 194338](https://github.com/user-attachments/assets/9c41f86a-733b-43d2-b9b5-02669742337f) 
![Screenshot 2024-10-09 194415](https://github.com/user-attachments/assets/12176a07-0ae9-4439-a928-839724d66f9f)

new password:
![Screenshot 2024-10-09 194435](https://github.com/user-attachments/assets/83a15d26-1741-4e41-b211-c3bf6412ddf8)

password changed:
![Screenshot 2024-10-09 194454](https://github.com/user-attachments/assets/9b735d16-f176-43d6-ad1f-cfde3e912ea0)




