### PR TITLE
Fix for Issue #63 - Login Button on Signup Page Returns 404

### DIFF
--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -224,7 +224,7 @@ const Page = () => {
             </Button>
             <p className="text-center text-sm">
               Already have an account?{" "}
-              <Link href="/login" className="text-blue-600 hover:underline">
+              <Link href="/sign-in" className="text-blue-600 hover:underline">
                 Log in
               </Link>
             </p>


### PR DESCRIPTION
## 📋 Description

This PR addresses the issue where clicking the Login button on the signup page results in a 404 error. The login route has been corrected to ensure that users are successfully redirected to the login page.

## 🔨 Changes Made

1. Updated the link for the Login button on the signup page to point to the correct login route.
2. Ensured proper navigation flow between the signup and login pages.

## 🏷️ Types of Changes

 Bug fix (non-breaking change which fixes an issue) 🐛




- Fixes #63